### PR TITLE
Mysql8 compatibility

### DIFF
--- a/drivers/mysql_backend.cpp
+++ b/drivers/mysql_backend.cpp
@@ -478,8 +478,8 @@ namespace prep {
 			std::vector<char> vbuf;
 			char *ptr;
 			unsigned long length;
-			my_bool is_null;
-			my_bool error;
+			bool is_null;
+			bool error;
 		};
 	public:
 
@@ -793,7 +793,7 @@ namespace prep {
 
 	class statement : public backend::statement {
 		struct param {
-			my_bool is_null;
+			bool is_null;
 			bool is_blob;
 			unsigned long length;
 			std::string value;
@@ -1225,7 +1225,7 @@ public:
 		}
 		if(ci.has("opt_reconnect")) {
 			if(unsigned reconnect = ci.get("opt_reconnect", 1)) {
-				my_bool value = reconnect;
+				bool value = reconnect;
 				mysql_set_option(MYSQL_OPT_RECONNECT, &value);
 			}
 		}
@@ -1241,7 +1241,7 @@ public:
 		}
 		if(ci.has("opt_ssl_verify_server_cert")) {
 			if(unsigned verify = ci.get("opt_ssl_verify_server_cert", 1)) {
-				my_bool value = verify;
+				bool value = verify;
 				mysql_set_option(MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &value);
 			}
 		}
@@ -1270,14 +1270,14 @@ public:
 		}
 		if(ci.has("report_data_truncation")) {
 			if(unsigned report = ci.get("report_data_truncation", 1)) {
-				my_bool value = report;
+				bool value = report;
 				mysql_set_option(MYSQL_REPORT_DATA_TRUNCATION, &value);
 			}
 		}
 #if MYSQL_VERSION_ID >= 40101
 		if(ci.has("secure_auth")) {
 			if(unsigned secure = ci.get("secure_auth", 1)) {
-				my_bool value = secure;
+				bool value = secure;
 				mysql_set_option(MYSQL_SECURE_AUTH, &value);
 			}
 		}

--- a/drivers/mysql_backend.cpp
+++ b/drivers/mysql_backend.cpp
@@ -1198,11 +1198,13 @@ public:
 				mysql_set_option(MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
 			}
 		}
+		#if (MYSQL_VERSION_ID < 80000) || defined(MARIADB_BASE_VERSION)
 		if(ci.has("opt_guess_connection")) {
 			if(ci.get("opt_guess_connection", 1)) {
 				mysql_set_option(MYSQL_OPT_GUESS_CONNECTION, NULL);
 			}
 		}
+		#endif
 		if(ci.has("opt_local_infile")) {
 			if(unsigned local_infile = ci.get("opt_local_infile", 0)) {
 				mysql_set_option(MYSQL_OPT_CONNECT_TIMEOUT, &local_infile);
@@ -1236,6 +1238,7 @@ public:
 		}
 #endif
 		std::string set_client_ip = ci.get("set_client_ip", "");
+		#if (MYSQL_VERSION_ID < 80000) || defined(MARIADB_BASE_VERSION)
 		if(!set_client_ip.empty()) {
 			mysql_set_option(MYSQL_SET_CLIENT_IP, set_client_ip.c_str());
 		}
@@ -1255,6 +1258,7 @@ public:
 				mysql_set_option(MYSQL_OPT_USE_REMOTE_CONNECTION, NULL);
 			}
 		}
+		#endif
 		if(ci.has("opt_write_timeout")) {
 			if(unsigned write_timeout = ci.get("opt_write_timeout", 0)) {
 				mysql_set_option(MYSQL_OPT_WRITE_TIMEOUT, &write_timeout);
@@ -1275,12 +1279,14 @@ public:
 			}
 		}
 #if MYSQL_VERSION_ID >= 40101
+		#if (MYSQL_VERSION_ID < 80000) || defined(MARIADB_BASE_VERSION)
 		if(ci.has("secure_auth")) {
 			if(unsigned secure = ci.get("secure_auth", 1)) {
 				bool value = secure;
 				mysql_set_option(MYSQL_SECURE_AUTH, &value);
 			}
 		}
+		#endif
 #endif
 		std::string set_charset_dir = ci.get("set_charset_dir", "");
 		if(!set_charset_dir.empty()) {


### PR DESCRIPTION
Fixes  https://github.com/artyom-beilis/cppcms/issues/70 
See my comments and references there.

My mysql8-compatibility branch has two commits:

The first commit removes my_bool altogether. 
Another contributor used a typedef instead.
https://github.com/alexbodn/cppdb/commit/4107cb801821a9bf80be9901f052ff1c29ba0dbb 
```
#if (MYSQL_VERSION_ID >= 80000) && !defined(MARIADB_BASE_VERSION)
typedef bool my_bool;
#endif
```
I don't know which approach you prefer.


The second commit put the code related to the embedded mysql server now removed upstream in between include guards.
I don't know if the whole code blocks should be deleted altogether or kept.

 